### PR TITLE
* eaf-browser.el: no need to set mode-line-format.

### DIFF
--- a/eaf-browser.el
+++ b/eaf-browser.el
@@ -437,9 +437,6 @@ This should be used after setting `eaf-browser-continue-where-left-off' to t."
             (bookmark-save)
             (message "Import success.")))))))
 
-;; Fix warn.
-(defvar eaf-mode-line-format)
-
 (defun eaf--create-new-browser-buffer (new-window-buffer-id)
   "Function for creating a new browser buffer with the specified NEW-WINDOW-BUFFER-ID."
   (let ((eaf-buffer
@@ -452,7 +449,6 @@ This should be used after setting `eaf-browser-continue-where-left-off' to t."
     (with-current-buffer eaf-buffer
       (eaf--gen-keybinding-map (eaf--get-app-bindings "browser"))
       (eaf-mode)
-      (setq-local mode-line-format eaf-mode-line-format)
       (set (make-local-variable 'eaf--buffer-id) new-window-buffer-id)
       (set (make-local-variable 'eaf--buffer-url) "")
       (set (make-local-variable 'eaf--buffer-app-name) "browser"))


### PR DESCRIPTION
	* eaf-browser.el (eaf-mode-line-format): removed.
	(eaf--create-new-browser-buffer): No need to set mode-line-format.