### PR TITLE
allow edit_url to search string

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -23,7 +23,7 @@ from PyQt5 import QtCore, QtWidgets
 from PyQt5.QtCore import QUrl, QTimer
 from PyQt5.QtGui import QColor, QCursor, QScreen
 from core.webengine import BrowserBuffer
-from core.utils import touch, interactive, is_port_in_use, eval_in_emacs, eval_get_result_in_emacs, message_to_emacs, set_emacs_var, translate_text, open_url_in_new_tab, get_emacs_var, get_emacs_vars, get_emacs_config_dir
+from core.utils import touch, interactive, is_port_in_use, eval_in_emacs, get_emacs_func_result, message_to_emacs, set_emacs_var, translate_text, open_url_in_new_tab, get_emacs_var, get_emacs_vars, get_emacs_config_dir
 from urllib.parse import urlparse
 import urllib
 import os
@@ -400,13 +400,12 @@ class AppBuffer(BrowserBuffer):
     @interactive(insert_or_do=True)
     def open_url_or_search_string(self, url):
         ''' Edit a URL or search a string.'''
-        is_valid_url = eval_get_result_in_emacs('eaf-is-valid-web-url', [url])
+        is_valid_url = get_emacs_func_result('eaf-is-valid-web-url', [url])
         if is_valid_url:
             self.buffer_widget.setUrl(QUrl(url))
         else:
-            search_url = eval_get_result_in_emacs('eaf--create-search-url', [url])
+            search_url = get_emacs_func_result('eaf--create-search-url', [url])
             self.buffer_widget.setUrl(QUrl(search_url))
-        pass
 
     def _clear_history(self):
         if os.path.exists(self.history_log_file_path):

--- a/eaf-browser.el
+++ b/eaf-browser.el
@@ -528,16 +528,12 @@ This function works best if paired with a fuzzy search package."
           ((eaf-is-valid-web-url history) (eaf-open-browser history))
           (t (eaf-search-it history)))))
 
-;;;###autoload
-(defun eaf-search-it (&optional search-string search-engine)
-  "Use SEARCH-ENGINE search SEARCH-STRING.
+(defun eaf--create-search-url (search-string &optional search-engine use-user-engine)
+  "Create a search-url for SEARCH-STRING using SEARCH-ENGINE.
 
-If called interactively, SEARCH-STRING is defaulted to symbol or region string.
-The user can enter a customized SEARCH-STRING.  SEARCH-ENGINE is defaulted
-to `eaf-browser-default-search-engine' with a prefix arg, the user is able to
-choose a search engine defined in `eaf-browser-search-engines'"
-  (interactive)
-  (let* ((real-search-engine (if current-prefix-arg
+SEARCH-ENGINE is defaulted to `eaf-browser-default-search-engine'.
+When USE-USER-ENGINE is non-nil, user can choose a search engine defined in `eaf-browser-search-engines'"
+  (let* ((real-search-engine (if use-user-engine
                                  (let ((all-search-engine (mapcar #'car eaf-browser-search-engines)))
                                    (completing-read
                                     (format "[EAF/browser] Select search engine (default %s): " eaf-browser-default-search-engine)
@@ -546,19 +542,31 @@ choose a search engine defined in `eaf-browser-search-engines'"
          (link (or (cdr (assoc real-search-engine
                                eaf-browser-search-engines))
                    (error (format "[EAF/browser] Search engine %s is unknown to EAF!" real-search-engine))))
-         (current-symbol (if mark-active
+         (search-url (format link search-string)))
+    search-url))
+
+;;;###autoload
+(defun eaf-search-it (&optional search-string search-engine)
+  "Use SEARCH-ENGINE search SEARCH-STRING.
+
+If called interactively, SEARCH-STRING is defaulted to symbol or region string.
+The user can enter a customized SEARCH-STRING. SEARCH-ENGINE is defaulted
+to `eaf-browser-default-search-engine' with a prefix arg, the user is able to
+choose a search engine defined in `eaf-browser-search-engines'"
+  (interactive)
+  (let* ((current-symbol (if mark-active
                              (if (eq major-mode 'pdf-view-mode)
                                  (progn
                                    (declare-function pdf-view-active-region-text "pdf-view.el")
                                    (car (pdf-view-active-region-text)))
                                (buffer-substring (region-beginning) (region-end)))
                            (symbol-at-point)))
-         (search-url (if search-string
-                         (format link search-string)
-                       (let ((search-string (read-string (format "[EAF/browser] Search (%s): " current-symbol))))
-                         (if (string-blank-p search-string)
-                             (format link current-symbol)
-                           (format link search-string))))))
+         (search-string (if search-string search-string
+                          (let ((search-string (read-string (format "[EAF/browser] Search (%s): " current-symbol))))
+                            (if (string-blank-p search-string) current-symbol
+                              search-string))))
+         (use-user-engine current-prefix-arg)
+         (search-url (eaf--create-search-url search-string search-engine use-user-engine)))
     (eaf-open search-url "browser")))
 
 (defun eaf--exit_fullscreen_request ()


### PR DESCRIPTION
Hi,

I created this PR which allows users to search for a string when editing URL (`e`).

Currently, when a user presses `e` to edit the URL and just type `foo`, then EAF browser will return a blank page.
Using this PR, EAF can allow use to search for the string `foo` by using the default search engine.

This PR is accompanied by the PR https://github.com/emacs-eaf/emacs-application-framework/pull/827 in the main EAF framework.

Here, I split `eaf-search-it` into 2 functions `eaf--create-search-url` and `eaf-search-it`.

The function `eaf--create-search-url` will be called by the main EAF webengine to create the search string.

Could you advise if this feature is useful and can be merged?

Thanks!