### PR TITLE
Revert "eaf-open-browser-with-history: support no http or https prefix."

### DIFF
--- a/eaf-browser.el
+++ b/eaf-browser.el
@@ -527,7 +527,6 @@ This function works best if paired with a fuzzy search package."
                                               (match-string 1 history)))))
     (cond (history-url (eaf-open-browser history-url))
           ((eaf-is-valid-web-url history) (eaf-open-browser history))
-          ((eaf-is-valid-web-url (eaf-wrap-url history)) (eaf-open-browser history))
           (t (eaf-search-it history)))))
 
 (defun eaf--create-search-url (search-string &optional search-engine use-user-engine)


### PR DESCRIPTION
Reverts emacs-eaf/eaf-browser#11

