### PR TITLE
support customizable progress bar's color and height

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -99,7 +99,11 @@ class AppBuffer(BrowserBuffer):
         self.caret_browsing_js_raw = None
         self.progressbar_progress = 0
         self.progressbar_height = int(get_emacs_var("eaf-browser-progress-bar-height"))
-        self.progressbar_color = get_emacs_var("eaf-browser-progress-bar-color")
+        custom_progressbar_color = get_emacs_var("eaf-browser-progress-bar-color")
+        if custom_progressbar_color == "default":
+            self.progressbar_color = QColor(self.theme_foreground_color)
+        else:
+            self.progressbar_color = QColor(custom_progressbar_color)
         self.buffer_widget.loadStarted.connect(self.start_progress)
         self.buffer_widget.loadProgress.connect(self.update_progress)
         self.is_loading = False
@@ -142,7 +146,7 @@ class AppBuffer(BrowserBuffer):
     def drawForeground(self, painter, rect):
         # Draw progress bar.
         if self.progressbar_progress > 0 and self.progressbar_progress < 100:
-            painter.setBrush(QColor(self.progressbar_color))
+            painter.setBrush(self.progressbar_color)
             painter.drawRect(0, 0, rect.width() * self.progressbar_progress * 1.0 / 100, self.progressbar_height)
 
     @QtCore.pyqtSlot()

--- a/buffer.py
+++ b/buffer.py
@@ -99,11 +99,7 @@ class AppBuffer(BrowserBuffer):
         self.caret_browsing_js_raw = None
         self.progressbar_progress = 0
         self.progressbar_height = int(get_emacs_var("eaf-browser-progress-bar-height"))
-        custom_progressbar_color = get_emacs_var("eaf-browser-progress-bar-color")
-        if custom_progressbar_color == "default":
-            self.progressbar_color = QColor(self.theme_foreground_color)
-        else:
-            self.progressbar_color = QColor(custom_progressbar_color)
+        self.progressbar_color = QColor(get_emacs_var("eaf-browser-progress-bar-color"))
         self.buffer_widget.loadStarted.connect(self.start_progress)
         self.buffer_widget.loadProgress.connect(self.update_progress)
         self.is_loading = False

--- a/buffer.py
+++ b/buffer.py
@@ -98,7 +98,8 @@ class AppBuffer(BrowserBuffer):
         # Draw progressbar.
         self.caret_browsing_js_raw = None
         self.progressbar_progress = 0
-        self.progressbar_height = 2
+        self.progressbar_height = int(get_emacs_var("eaf-browser-progress-bar-height"))
+        self.progressbar_color = get_emacs_var("eaf-browser-progress-bar-color")
         self.buffer_widget.loadStarted.connect(self.start_progress)
         self.buffer_widget.loadProgress.connect(self.update_progress)
         self.is_loading = False
@@ -141,7 +142,7 @@ class AppBuffer(BrowserBuffer):
     def drawForeground(self, painter, rect):
         # Draw progress bar.
         if self.progressbar_progress > 0 and self.progressbar_progress < 100:
-            painter.setBrush(QColor(self.theme_foreground_color))
+            painter.setBrush(QColor(self.progressbar_color))
             painter.drawRect(0, 0, rect.width() * self.progressbar_progress * 1.0 / 100, self.progressbar_height)
 
     @QtCore.pyqtSlot()

--- a/eaf-browser.el
+++ b/eaf-browser.el
@@ -150,6 +150,14 @@ and will re-open them when calling `eaf-browser-restore-buffers' in the future s
   ""
   :type 'string)
 
+(defcustom eaf-browser-progress-bar-height "5"
+  ""
+  :type 'int)
+
+(defcustom eaf-browser-progress-bar-color "#ff8103"
+  ""
+  :type 'string)
+
 (defcustom eaf-browser-blank-page-url "https://www.google.com"
   ""
   :type 'string)

--- a/eaf-browser.el
+++ b/eaf-browser.el
@@ -150,11 +150,17 @@ and will re-open them when calling `eaf-browser-restore-buffers' in the future s
   ""
   :type 'string)
 
-(defcustom eaf-browser-progress-bar-height "5"
+(defcustom eaf-browser-progress-bar-height "2"
   ""
   :type 'int)
 
-(defcustom eaf-browser-progress-bar-color "#ff8103"
+(defcustom eaf-browser-progress-bar-color "default"
+  "Possible values are `default' or a hex code `#hhhhhh' of a color.
+If it is set to `default', then the default theme foreground color
+(set by `eaf-emacs-theme-foreground-color') will be used."
+  :type 'string)
+
+(defcustom eaf-browser-text-selection-color "#ffb800"
   ""
   :type 'string)
 

--- a/eaf-browser.el
+++ b/eaf-browser.el
@@ -154,14 +154,9 @@ and will re-open them when calling `eaf-browser-restore-buffers' in the future s
   ""
   :type 'int)
 
-(defcustom eaf-browser-progress-bar-color "default"
-  "Possible values are `default' or a hex code `#hhhhhh' of a color.
-If it is set to `default', then the default theme foreground color
-(set by `eaf-emacs-theme-foreground-color') will be used."
-  :type 'string)
-
-(defcustom eaf-browser-text-selection-color "#ffb800"
-  ""
+(defcustom eaf-browser-progress-bar-color (eaf-get-theme-foreground-color)
+  "Color of progress bar in hex code `#hhhhhh'.
+Default is the foreground color of EAF buffer."
   :type 'string)
 
 (defcustom eaf-browser-blank-page-url "https://www.google.com"


### PR DESCRIPTION
Hi,

The current height of the progress bar is quite small (2) and its color is the same as text color, so it's difficult to see.

In this PR, I make it customizable, increase the default height to 5 and change the color to orange so that it is easier to see.

Please consider merging it.

Thank you!
