### PR TITLE
show current page position in mode-line

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -109,6 +109,9 @@ class AppBuffer(BrowserBuffer):
         self.buffer_widget.loadProgress.connect(self.update_progress)
         self.is_loading = False
 
+        # Update page position
+        self.buffer_widget.web_page.scrollPositionChanged.connect(self.update_position)
+
         # Reset to default zoom when page init or page url changed.
         self.reset_default_zoom()
         self.buffer_widget.urlChanged.connect(lambda url: self.reset_default_zoom())
@@ -214,6 +217,13 @@ class AppBuffer(BrowserBuffer):
         self.init_pw_autofill()
         if self.enable_adblocker:
             self.load_adblocker()
+
+    def update_position(self):
+        position = self.buffer_widget.web_page.scrollPosition().y();
+        view_height = self.buffer_widget.height()
+        page_height = self.buffer_widget.web_page.contentsSize().height()
+        pos_percentage = '%.1f%%' % ((position + view_height) / page_height * 100)
+        eval_in_emacs("eaf--browser-update-position", [pos_percentage])
 
     def handle_input_response(self, callback_tag, result_content):
         ''' Handle input message.'''

--- a/eaf-browser.el
+++ b/eaf-browser.el
@@ -369,6 +369,11 @@ configured by darkreader.js."
   "The key alias of EAF Browser."
   :type 'cons)
 
+(defun eaf--browser-update-position (position-percentage)
+  "Format mode line position indicator to show the current position in percentage."
+  (setq-local mode-line-position `(,position-percentage))
+  (force-mode-line-update))
+
 (defun eaf-browser-restore-buffers ()
   "EAF restore all opened EAF Browser buffers in the previous Emacs session.
 


### PR DESCRIPTION
Hi,

This PR will help to show the current position in percentage (%) of a website in mode-line. It looks like below:

![position](https://user-images.githubusercontent.com/193967/135248502-e583f63c-01fa-425f-a2fa-77fea1968831.png)


