### PR TITLE
assign shortcut key M-e to edit atomic or searched text

### DIFF
--- a/eaf-browser.el
+++ b/eaf-browser.el
@@ -276,7 +276,7 @@ configured by darkreader.js."
     ("C-v" . "scroll_up_page")
     ("C-y" . "yank_text")
     ("C-w" . "kill_text")
-    ("M-e" . "atomic_edit")
+    ("M-e" . "edit_atomic_or_search_text")
     ("M-c" . "caret_toggle_browsing")
     ("M-D" . "select_text")
     ("M-s" . "open_link")


### PR DESCRIPTION
Hi,

This is an accompanied PR with https://github.com/emacs-eaf/emacs-application-framework/pull/863 to assign the shortcut key `M-e` for both atomic edit and edit search text.