### PR TITLE
fix type error when update mode-line position

### DIFF
--- a/eaf-browser.el
+++ b/eaf-browser.el
@@ -718,7 +718,10 @@ Otherwise send key 'esc' to browser."
   (eaf-call-sync "toggle_proxy"))
 
 (defun eaf-get-mode-line-height ()
-  (face-attribute 'mode-line :height))
+  (let ((mode-line-height (face-attribute 'mode-line :height)))
+    (if (eq mode-line-height 'unspecified)
+        1.0
+      mode-line-height)))
 
 (add-to-list 'eaf-app-binding-alist '("browser" . eaf-browser-keybinding))
 


### PR DESCRIPTION
mode-line face 的 height 属性可以为多种类型，因此下面代码中 mode_line_height 也可能会是几种不同类型（float，int，sexpdata.Symbol）
https://github.com/emacs-eaf/eaf-browser/blob/fb5ef142aa628d4d21667907df996b7075007e20/buffer.py#L210-L217

这个补丁设置如果 (face-attribute 'mode-line :height) 返回 unspecified, 则 eaf-get-mode-line-height 返回 1.0 。