### PR TITLE
support both dark and light theme in dark mode

### DIFF
--- a/eaf-browser.el
+++ b/eaf-browser.el
@@ -156,6 +156,10 @@ If it is set to `auto', then the selection color will be automatically
 configured by darkreader.js."
   :type 'string)
 
+(defcustom eaf-browser-dark-mode-theme "dark"
+  "Possible values are `dark' or `light' theme of the dark mode."
+  :type 'string)
+
 (defcustom eaf-browser-blank-page-url "https://www.google.com"
   "Set the blank page url for EAF Browser."
   :type 'string)


### PR DESCRIPTION
Hi,

In this PR, I implement a feature to allow eaf-browser to display in either a light theme or a dark theme in the dark mode. This option is controlled by the new variable `eaf-browser-dark-mode-theme`, when it is set to `light` or `dark`.

It is accompanied by https://github.com/emacs-eaf/emacs-application-framework/pull/1018

Here is an example of the light theme (when dark-mode is enabled):

![emacs-light](https://user-images.githubusercontent.com/193967/194316509-7002c31b-1f9f-4fcb-82c1-dde2cf843e20.png)

And her is the original dark theme:

![emacs-dark](https://user-images.githubusercontent.com/193967/194316556-e4131c19-759b-493a-b4d2-676bacd25e85.png)

Can you review and consider merging it?

Thanks!
