### PR TITLE
support toggle dark mode between light theme or dark theme

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -141,15 +141,9 @@ class AppBuffer(BrowserBuffer):
 
         if found_braveblock:
             self.interceptor = AdBlockInterceptor(self.profile, self)
-        
+
     @interactive
     def update_theme(self):
-        (self.text_selection_color,
-         self.dark_mode_theme
-         ) = get_emacs_vars([
-             "eaf-browser-text-selection-color",
-             "eaf-browser-dark-mode-theme"])
-
         self.buffer_widget.init_dark_mode_js(__file__,
                                              self.text_selection_color,
                                              self.dark_mode_theme,
@@ -333,6 +327,18 @@ class AppBuffer(BrowserBuffer):
                     message_to_emacs("No page need recovery.")
         else:
             message_to_emacs("No page need recovery.")
+
+    @interactive
+    def toggle_dark_mode_light_theme(self):
+        if self.dark_mode_theme == "dark":
+            self.dark_mode_theme = "light"
+        else:
+            self.dark_mode_theme = "dark"
+
+        self.update_theme()
+
+        message_to_emacs("Toggle dark mode light theme")
+
 
     @interactive
     def toggle_adblocker(self):

--- a/buffer.py
+++ b/buffer.py
@@ -143,7 +143,14 @@ class AppBuffer(BrowserBuffer):
             self.interceptor = AdBlockInterceptor(self.profile, self)
 
     @interactive
-    def update_theme(self):
+    def update_theme(self, reload_config=True):
+        if reload_config:
+            (self.text_selection_color,
+             self.dark_mode_theme
+             ) = get_emacs_vars([
+                 "eaf-browser-text-selection-color",
+                 "eaf-browser-dark-mode-theme"])
+
         self.buffer_widget.init_dark_mode_js(__file__,
                                              self.text_selection_color,
                                              self.dark_mode_theme,
@@ -335,7 +342,7 @@ class AppBuffer(BrowserBuffer):
         else:
             self.dark_mode_theme = "dark"
 
-        self.update_theme()
+        self.update_theme(False)
 
         message_to_emacs("Toggle dark mode light theme")
 

--- a/eaf-browser.el
+++ b/eaf-browser.el
@@ -285,6 +285,7 @@ Options:
     ("M-p" . "duplicate_page")
     ("M-t" . "new_blank_page")
     ("M-d" . "toggle_dark_mode")
+    ("M-l" . "toggle_dark_mode_light_theme")
     ("SPC" . "insert_or_scroll_up_page")
     ("J" . "insert_or_select_left_tab")
     ("K" . "insert_or_select_right_tab")


### PR DESCRIPTION
Hi,

I implemented a small PR to allow users quickly switch between the light theme and dark theme of dark mode.

This is relevant to this PR: https://github.com/emacs-eaf/eaf-browser/pull/43

Can you consider merging it?

Thanks!