### PR TITLE
feat: add a feature to import cookies from Chrome automatically.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,16 @@ Browser application for the [Emacs Application Framework](https://github.com/ema
 
 ### Dependency List
 
-| Package   | Description                 |
-| :-------- | :------                     |
-| aria2     | Download files from the web |
+| Package                                                    | Description                 |
+|:-----------------------------------------------------------|:----------------------------|
+| aria2                                                      | Download files from the web |
+| [pycookiecheat](https://github.com/n8henrie/pycookiecheat) | Import cookies from Chrome  |
+
+### Import cookies from Chrome
+
+When you are used to using Chrome, you can set `eaf-browser-auto-import-chrome-cookies` to `t`, and the EAF browser will automatically import cookies from Chrome. You don't need to login separately in Chrome and EAF browser.
+
+[Do not Support Windows](https://github.com/n8henrie/pycookiecheat#how-about-windows)
 
 ### The keybinding of EAF Browser.
 

--- a/eaf-browser.el
+++ b/eaf-browser.el
@@ -210,6 +210,10 @@ Options:
   "The default chrome bookmark file to import."
   :type 'string)
 
+(defcustom eaf-browser-auto-import-chrome-cookies nil
+  "If non-nil, import cookies from chrome."
+  :type 'boolean)
+
 (defcustom eaf-browser-caret-mode-keybinding
   '(("j"   . "caret_next_line")
     ("k"   . "caret_previous_line")


### PR DESCRIPTION
Add a feature to import cookies from Chrome.

 You can set `eaf-browser-auto-import-chrome-cookies` to `t`, and the EAF browser will automatically import cookies from Chrome. 

You don't need to login separately in Chrome and EAF browser.