### PR TITLE
Support import chrome based browser cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ Browser application for the [Emacs Application Framework](https://github.com/ema
 
 When you are used to using Chrome, you can set `eaf-browser-auto-import-chrome-cookies` to `t`, and the EAF browser will automatically import cookies from Chrome. You don't need to login separately in Chrome and EAF browser.
 
+#### Support chrome based browser
+
+Support import chrome based browser cooike by set `eaf-browser-chrome-browser-name` to:
+
+1. Chrome (default)
+2. Chromium
+3. Brave
+
 [Do not Support Windows](https://github.com/n8henrie/pycookiecheat#how-about-windows)
 
 ### The keybinding of EAF Browser.
@@ -134,4 +142,3 @@ Please press `Alt + z` to execute command `switch_to_input_mode` if some site ca
 | `C-<right>` | eaf-send-ctrl-right-sequence |
 | `C-<delete>` | eaf-send-ctrl-delete-sequence |
 | `C-<backspace>` | eaf-send-ctrl-backspace-sequence |
-

--- a/buffer.py
+++ b/buffer.py
@@ -63,7 +63,8 @@ class AppBuffer(BrowserBuffer):
          self.translate_language,
          self.text_selection_color,
          self.dark_mode_theme,
-         self.auto_import_chrome_cookies
+         self.auto_import_chrome_cookies,
+         self.chrome_browser_name
          ) = get_emacs_vars([
              "eaf-browser-dark-mode",
              "eaf-browser-remember-history",
@@ -78,7 +79,8 @@ class AppBuffer(BrowserBuffer):
              "eaf-browser-translate-language",
              "eaf-browser-text-selection-color",
              "eaf-browser-dark-mode-theme",
-             "eaf-browser-auto-import-chrome-cookies"
+             "eaf-browser-auto-import-chrome-cookies",
+             "eaf-browser-chrome-browser-name"
          ])
 
         # Use thread to avoid slow down open speed.
@@ -140,22 +142,22 @@ class AppBuffer(BrowserBuffer):
 
         if found_braveblock and self.enable_adblocker:
             self.interceptor = AdBlockInterceptor(self.profile, self)
-       
+
         if self.auto_import_chrome_cookies:
             # import cookies from Chrome automatically
             self.import_chrome_cookies(url)
 
     def import_chrome_cookies(self, url):
         from urllib.parse import urlparse
-        from pycookiecheat import chrome_cookies # package that fetches cookies 
+        from pycookiecheat import chrome_cookies # package that fetches cookies
         from PyQt6.QtNetwork import QNetworkCookie
         cookieStore = self.buffer_widget.page().profile().cookieStore()
-        cookies = chrome_cookies(url)
+        cookies = chrome_cookies(url, browser=self.chrome_browser_name)
         for name, value in cookies.items():
             qcookie = QNetworkCookie()
             qcookie.setName(name.encode())
             qcookie.setValue(value.encode())
-            qcookie.setDomain(urlparse(url).netloc)                
+            qcookie.setDomain(urlparse(url).netloc)
             cookieStore.setCookie(qcookie, QUrl())
 
     @interactive

--- a/eaf-browser.el
+++ b/eaf-browser.el
@@ -214,6 +214,10 @@ Options:
   "If non-nil, import cookies from chrome."
   :type 'boolean)
 
+(defcustom eaf-browser-chrome-browser-name "Chrome"
+  "The real chrome execute name, default is Chrome."
+  :type 'string)
+
 (defcustom eaf-browser-caret-mode-keybinding
   '(("j"   . "caret_next_line")
     ("k"   . "caret_previous_line")


### PR DESCRIPTION
Hi:
    I add a patch to support import chrome based browser(like Chromium, Brave) cookie by set `eaf-browser-chrome-browser-name`, Please review. Thanks!