### PR TITLE
Mark regexp string as "raw".

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -215,7 +215,7 @@ class AppBuffer(BrowserBuffer):
                 for raw_his in raw_list:
                     his_line = re.match(self.history_pattern, raw_his)
                     if his_line is None: # Obsolete Old history format
-                        old_his = re.match("(.*)\s((https?|file):[^\s]+)$", raw_his)
+                        old_his = re.match(r"(.*)\s((https?|file):[^\s]+)$", raw_his)
                         if old_his is not None:
                             self.history_list.append(HistoryPage(old_his.group(1), old_his.group(2), 1))
                     else:


### PR DESCRIPTION
Fix warning:

```
Warning: invalid escape sequence '\s'
  old_his = re.match("(.*)\s((https?|file):[^\s]+)$", raw_his)
```

(other regexps in this file are marked as "raw")